### PR TITLE
Disabled Change Duration Popup, enable again once backend updates.

### DIFF
--- a/lib/views/hike_screen.dart
+++ b/lib/views/hike_screen.dart
@@ -566,10 +566,12 @@ class _HikeScreenState extends State<HikeScreen> {
                                   text:
                                       'Long Press on any hiker to hand over the beacon\n',
                                   style: TextStyle(fontSize: 16)),
-                              TextSpan(
-                                  text:
-                                      'Double tap on beacon to change the duration\n',
-                                  style: TextStyle(fontSize: 14)),
+                              //TODO: enable this once backend has updated.
+                              //Commented, since we dont have the neccessary mutation atm on backend to change the duration.
+                              // TextSpan(
+                              //     text:
+                              //         'Double tap on beacon to change the duration\n',
+                              //     style: TextStyle(fontSize: 14)),
                             ]),
                       ),
                     )
@@ -616,7 +618,10 @@ class _HikeScreenState extends State<HikeScreen> {
                                     ? Fluttertoast.showToast(
                                         msg:
                                             'Only beacon holder has access to change the duration')
-                                    : DialogBoxes.changeDurationDialog(context);
+                                    //TODO: enable this once backend has updated.
+                                    //Commented, since we dont have the neccessary mutation atm on backend to change the duration.
+                                    // : DialogBoxes.changeDurationDialog(context);
+                                    : Container();
                               },
                               child: Icon(
                                 Icons.room,


### PR DESCRIPTION
Since we dont have the required mutation on backend, disabling the mentioned dialogue as suggested.