### PR TITLE
Eye Icon changed

### DIFF
--- a/lib/views/auth_screen.dart
+++ b/lib/views/auth_screen.dart
@@ -225,8 +225,8 @@ class _AuthScreenState extends State<AuthScreen>
                               onPressed: () => model.displayPasswordLogin(),
                               icon: Icon(
                                 model.obscureTextLogin
-                                    ? Icons.remove_red_eye_sharp
-                                    : Icons.remove_red_eye_outlined,
+                                    ? Icons.visibility
+                                    : Icons.visibility_off,
                                 size: 20.0,
                                 color: Colors.black,
                               ),
@@ -375,8 +375,8 @@ class _AuthScreenState extends State<AuthScreen>
                               onPressed: () => model.displayPasswordSignup(),
                               icon: Icon(
                                 model.obscureTextSignup
-                                    ? Icons.remove_red_eye_sharp
-                                    : Icons.remove_red_eye_outlined,
+                                    ? Icons.visibility
+                                    : Icons.visibility_off,
                                 size: 20.0,
                                 color: Colors.black,
                               ),


### PR DESCRIPTION
Fixes #65 

Describe the changes you have made in this PR - Changed eye icon in the password field: Priorly it just changed boldness upon clicking. Now it changes its state by putting a slash upon it. 

Screenshots of the changes (If any) - 

<img src="https://user-images.githubusercontent.com/69353350/149569495-34545a9b-6b3c-4e1e-a5e4-6d5d63df9340.jpeg" height="500"/>


Note: Please check Allow edits from maintainers, if you would like us to assist in the PR.