### PR TITLE
Changed beacon card sizing

### DIFF
--- a/lib/components/beacon_card.dart
+++ b/lib/components/beacon_card.dart
@@ -40,7 +40,6 @@ class BeaconCustomWidgets {
           vertical: 10.0,
           horizontal: 10.0,
         ),
-        height: 110,
         padding: EdgeInsets.only(left: 16.0, right: 16.0, bottom: 8, top: 8),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
Fixes #67 

Describe the changes you have made in this PR - Removed predefined beacon card height to avoid any overflowing error

Screenshots of the changes (If any) - 
<img src="https://user-images.githubusercontent.com/69353350/149571135-1c859629-23d0-4564-a440-62f7e3be34c1.jpeg" width="500"/> <img src="https://user-images.githubusercontent.com/69353350/149571293-15c0b901-0406-44c4-bade-b227cd37ef04.jpg" height="500"/>

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.