### PR TITLE
A small leftout UI fix

### DIFF
--- a/lib/views/auth_screen.dart
+++ b/lib/views/auth_screen.dart
@@ -145,7 +145,7 @@ class _AuthScreenState extends State<AuthScreen>
     return Container(
       padding: EdgeInsets.symmetric(horizontal: 13.5.w),
       width: screensize.width,
-      height: 6.h,
+      height: MediaQuery.of(context).size.height < 800 ? 7.5.h : 6.h,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.all(Radius.circular(25.0)),
       ),

--- a/lib/views/auth_screen.dart
+++ b/lib/views/auth_screen.dart
@@ -145,7 +145,7 @@ class _AuthScreenState extends State<AuthScreen>
     return Container(
       padding: EdgeInsets.symmetric(horizontal: 13.5.w),
       width: screensize.width,
-      height: MediaQuery.of(context).size.height < 800 ? 7.5.h : 6.h,
+      height: screensize.height < 800 ? 7.5.h : 6.h,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.all(Radius.circular(25.0)),
       ),


### PR DESCRIPTION
A small fix left out in PR #63. My apologies for forgetting this out.

Describe the changes you have made in this PR - Fixed unusual look of tab buttons in the login screen for small screen sizes. The problem is as shown:

<img src="https://user-images.githubusercontent.com/69353350/151656732-b5300dfa-305c-43d1-b08c-17ad22f0fce1.png" height="500"/>

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.