### PR TITLE
Fixed: Build error when tabs are switched immediately after timer hits 0

### DIFF
--- a/lib/components/timer.dart
+++ b/lib/components/timer.dart
@@ -35,7 +35,7 @@ class _CountdownTimerPageState extends State<CountdownTimerPage>
         CountdownTimerController(endTime: endTime, onEnd: onEnd, vsync: this);
   }
 
-  void onEnd() {
+  void onEnd() async {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         duration: Duration(seconds: 5),


### PR DESCRIPTION
Fixes #124 

Describe the changes you have made in this PR - Added async to `onEnd` function in timer.dart