### PR TITLE
Changed text style on initial login

### DIFF
--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -1,6 +1,5 @@
 import 'package:beacon/components/beacon_card.dart';
 import 'package:beacon/components/create_join_dialog.dart';
-
 import 'package:beacon/components/hike_button.dart';
 import 'package:beacon/components/shape_painter.dart';
 import 'package:beacon/locator.dart';
@@ -261,7 +260,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
                                                                           text:
                                                                               'Join',
                                                                           style:
-                                                                              TextStyle(color: kYellow)),
+                                                                              TextStyle(fontWeight: FontWeight.bold)),
                                                                       TextSpan(
                                                                           text:
                                                                               ' a Hike or '),
@@ -269,7 +268,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
                                                                           text:
                                                                               'Create',
                                                                           style:
-                                                                              TextStyle(color: kYellow)),
+                                                                              TextStyle(fontWeight: FontWeight.bold)),
                                                                       TextSpan(
                                                                           text:
                                                                               '  a new one! '),


### PR DESCRIPTION
Fixes #132 

Describe the changes you have made in this PR -

Changed text on initial login from standard yellow to bold black to avoid confusion

Screenshots of the changes (If any) -
![Screenshot0](https://user-images.githubusercontent.com/58381523/153725679-b6bab8ab-4907-4747-af3d-1b1f63d4abb3.jpg)


Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.