### PR TITLE
Fixed location permission keys in Info.plist file

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -42,7 +42,9 @@
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>App needs access to your location to start the hike</string>
 	<key>NSLocationAlwaysUsageDescription</key>
+	<string>App needs access to your location to start the hike</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 </dict>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -42,9 +42,9 @@
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>App needs access to your location to start the hike</string>
+	<string>Your location is needed to guide you during the hike and show your location to the group</string>
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string>App needs access to your location to start the hike</string>
+	<string>Your location is needed to guide you during the hike and show your location to the group</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 </dict>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,5 +41,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #194 

Describe the changes you have made in this PR -

- Added the location permission keys to the app's Info.plist file to enable location access when the app is in use. This resolves an issue where ios app users were not able to start the beacon due to missing location permissions.
- The "CADisableMinimumFrameDurationOnPhone" key was added to support higher refresh rates on iOS devices, particularly iPhone 13 Pro and newer models, which have a ProMotion display capable of variable refresh rates up to 120hz. By default, iOS restricts apps to a maximum refresh rate of 60hz, but this key disables the minimum frame duration limit enforced by Core Animation, allowing apps to take advantage of higher frame rates if the device supports it.

Screenshots of the changes (If any) 
Before
<img width="298" alt="image" src="https://user-images.githubusercontent.com/104641430/226141461-2e7a3a6a-8358-48b2-90d7-2fbb8691de93.png">

After
<img width="228" alt="image" src="https://user-images.githubusercontent.com/104641430/226141441-c30eb6d4-52b4-4588-ae0e-9a85abfa181b.png">




Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.