### PR TITLE
Fix: App crash on joining active hike due to google maps 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,11 @@ allprojects {
         google()
         jcenter()
     }
+    configurations.all {
+        resolutionStrategy {
+            force "com.google.android.gms:play-services-location:21.0.1"
+        }
+    }
 }
 
 rootProject.buildDir = '../build'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableDexingArtifactTransform=false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableDexingArtifactTransform=false


### PR DESCRIPTION
Fixes #205 

Describe the changes you have made in this PR -
The error log suggests an IncompatibleClassChangeError in the com.example.beacon process, with a message indicating that the code found an interface(com.google.android.gms.location.FusedLocationProviderClient) where a class was expected. This error can occur when different versions of the same library are used in the project, or when there is a mismatch between the libraries used by different modules or libraries. To fix this error below-mentioned change were made:

- The resolutionStrategy block is used to force the version of the com.google.android.gms:play-services-location library to 21.0.1 for all dependencies in the project to resolve any conflicting dependencies.


Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.