### PR TITLE
[fix] multi_heros

### DIFF
--- a/lib/components/hike_screen_widget.dart
+++ b/lib/components/hike_screen_widget.dart
@@ -31,6 +31,8 @@ class HikeScreenWidget extends ChangeNotifier {
 
   static Widget shareButton(BuildContext context, String passkey) {
     return FloatingActionButton(
+        heroTag:
+          'shareRouteTag1', //had to pass this tag else we would get error since there will be two FAB in the same subtree with the same tag.
       onPressed: () {
         showDialog(
           context: context,
@@ -105,7 +107,7 @@ class HikeScreenWidget extends ChangeNotifier {
   ) {
     return FloatingActionButton(
       heroTag:
-          'shareRouteTag', //had to pass this tag else we would get error since there will be two FAB in the same subtree with the same tag.
+          'shareRouteTag1', //had to pass this tag else we would get error since there will be two FAB in the same subtree with the same tag.
       onPressed: () async {
         final mapController = await googleMapControllerCompleter.future;
         // sanity check.

--- a/lib/components/hike_screen_widget.dart
+++ b/lib/components/hike_screen_widget.dart
@@ -31,7 +31,7 @@ class HikeScreenWidget extends ChangeNotifier {
 
   static Widget shareButton(BuildContext context, String passkey) {
     return FloatingActionButton(
-        heroTag:
+      heroTag:
           'shareRouteTag1', //had to pass this tag else we would get error since there will be two FAB in the same subtree with the same tag.
       onPressed: () {
         showDialog(


### PR DESCRIPTION
Fixes #193 

Description:
This pull request addresses an issue in the Beacon project where multiple FloatingActionButton widgets were sharing the same Hero tag, causing a conflict within the widget subtree.

Changes Made:
- Assigned unique Hero tags to each FloatingActionButton to ensure they are distinguishable within the widget tree.

This change resolves the Hero tag conflict and ensures that each FloatingActionButton operates independently as expected. This contributes to a smoother user experience and prevents potential issues with widget rendering and transitions.