### PR TITLE
notifications fixed

### DIFF
--- a/lib/services/local_notification.dart
+++ b/lib/services/local_notification.dart
@@ -48,13 +48,13 @@ class LocalNotification {
   }
 
   Future<void> scheduleNotification(Beacon beacon) async {
-    var scheduledDate = await tz.TZDateTime.from(
+    var scheduledDate1 = await tz.TZDateTime.from(
         DateTime.fromMillisecondsSinceEpoch(beacon.startsAt!), tz.local);
     await flutterLocalNotificationsPlugin.zonedSchedule(
       beacon.id.hashCode,
       'Hike ' + beacon.title! + ' has started',
       'Click here to join!',
-      scheduledDate,
+      scheduledDate1,
       NotificationDetails(
         android: AndroidNotificationDetails(
           'channel id',
@@ -78,15 +78,21 @@ class LocalNotification {
     );
     // We have to check if the hike is after 1 hour or not
 
-    scheduledDate = await tz.TZDateTime.from(
+    var scheduledDate2 = await tz.TZDateTime.from(
       DateTime.fromMillisecondsSinceEpoch(beacon.startsAt!),
       tz.local,
     ).subtract(Duration(hours: 1));
+
+    if (!scheduledDate2.isAfter(tz.TZDateTime.from(
+        DateTime.fromMillisecondsSinceEpoch(beacon.startsAt!), tz.local))) {
+      return;
+    }
+
     await flutterLocalNotificationsPlugin.zonedSchedule(
       beacon.id.hashCode,
       'Reminder: ' + beacon.title! + ' will start in an hour',
       'Get Ready!',
-      scheduledDate,
+      scheduledDate2,
       NotificationDetails(
         android: AndroidNotificationDetails(
           'channel id',


### PR DESCRIPTION

The second notification was scheduled in the past, which is not allowed. To address this issue, I've implemented a validation check to ensure that the second scheduled notification time occurs after the beacon start time.

#215 