### PR TITLE
Multi hero tag

### DIFF
--- a/lib/components/hike_screen_widget.dart
+++ b/lib/components/hike_screen_widget.dart
@@ -30,6 +30,8 @@ class HikeScreenWidget extends ChangeNotifier {
 
   static Widget shareButton(BuildContext context, String? passkey) {
     return FloatingActionButton(
+       heroTag:
+          'shareRouteTag', //had to pass this tag else we would get error since there will be two FAB in the same subtree with the same tag.
       onPressed: () {
         showDialog(
           context: context,
@@ -104,7 +106,7 @@ class HikeScreenWidget extends ChangeNotifier {
   ) {
     return FloatingActionButton(
       heroTag:
-          'shareRouteTag', //had to pass this tag else we would get error since there will be two FAB in the same subtree with the same tag.
+          'shareRouteTag1', //had to pass this tag else we would get error since there will be two FAB in the same subtree with the same tag.
       onPressed: () async {
         final mapController = await googleMapControllerCompleter.future;
         // sanity check.

--- a/lib/services/local_notification.dart
+++ b/lib/services/local_notification.dart
@@ -81,7 +81,7 @@ class LocalNotification {
     scheduledDate = await tz.TZDateTime.from(
       DateTime.fromMillisecondsSinceEpoch(beacon.startsAt!),
       tz.local,
-    ).subtract(Duration(hours: 1));
+    );
     await flutterLocalNotificationsPlugin.zonedSchedule(
       beacon.id.hashCode,
       'Reminder: ' + beacon.title! + ' will start in an hour',

--- a/lib/services/local_notification.dart
+++ b/lib/services/local_notification.dart
@@ -81,7 +81,7 @@ class LocalNotification {
     scheduledDate = await tz.TZDateTime.from(
       DateTime.fromMillisecondsSinceEpoch(beacon.startsAt!),
       tz.local,
-    );
+    ).subtract(Duration(hours: 1));
     await flutterLocalNotificationsPlugin.zonedSchedule(
       beacon.id.hashCode,
       'Reminder: ' + beacon.title! + ' will start in an hour',


### PR DESCRIPTION
Fixes #193 

**Description: **
 The issue of multiple heroes sharing the same tag within a subtree has been resolved. Previously, there was only one tag in the Floating Action Button (FAB), which caused conflicts when using it in two different instances. To rectify this, an additional tag has been added to the FAB, ensuring proper rendering and preventing hero tag clashes.