### PR TITLE
Repositioned Google Map Compass in Beacon Project

### DIFF
--- a/lib/views/hike_screen.dart
+++ b/lib/views/hike_screen.dart
@@ -143,7 +143,8 @@ class _HikeScreenState extends State<HikeScreen> {
                         // child: Text('hello'),
                         child: GoogleMap(
                             compassEnabled: true,
-                            padding: EdgeInsets.fromLTRB(320.0,520.0,0.0,0.0),
+                            padding:
+                                EdgeInsets.fromLTRB(320.0, 520.0, 0.0, 0.0),
                             mapType: MapType.terrain,
                             polylines: model.polylines,
                             initialCameraPosition: CameraPosition(

--- a/lib/views/hike_screen.dart
+++ b/lib/views/hike_screen.dart
@@ -143,6 +143,7 @@ class _HikeScreenState extends State<HikeScreen> {
                         // child: Text('hello'),
                         child: GoogleMap(
                             compassEnabled: true,
+                            padding: EdgeInsets.fromLTRB(320.0,520.0,0.0,0.0),
                             mapType: MapType.terrain,
                             polylines: model.polylines,
                             initialCameraPosition: CameraPosition(


### PR DESCRIPTION
Fixes #209 

Description: This PR addresses an issue in the Beacon project where the built-in compass of Google Maps was hidden behind the back. The problem has been resolved by repositioning the compass to the bottom right side of the hike screen. This change enhances the user interface and improves the overall user experience. Please review the changes and provide feedback. Thank you.</br>
<img src="https://github.com/CCExtractor/beacon/assets/143318563/445ac504-9a36-4b2e-8ef5-c5a51dd3f7e3" height="600px" width="300px">
