### PR TITLE
feat(home): add signup FAB for guest users

### DIFF
--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -135,6 +135,15 @@ class _HomeScreenState extends State<HomeScreen> {
                     //   size: Size(100.w, 100.h),
                     //   painter: DrawCircle(),
                     // ),
+                    if (localApi.userModel.isGuest == true) 
+                      Align(
+                        alignment: Alignment(0.7, -0.8),
+                        child: FloatingActionButton(
+                          onPressed: () => appRouter.pushNamed('/auth'),
+                          backgroundColor: kYellow,
+                          child: Icon(Icons.login, color: Colors.white),
+                        ),
+                      ),
                     Align(
                       alignment: Alignment(0.9, -0.8),
                       child: FloatingActionButton(


### PR DESCRIPTION
Fixes #

Describe the changes you have made in this PR -
-Added a dedicated signup FloatingActionButton(FAB) for guest users
-Visible only when (isGuest == true)
-Routes to '/auth' on press for seamless onboarding
-Positioned at 'Alignment(0.7, -0.8)' to avoid UI clutter

Screenshots of the changes (If any) -
Due to a local environmental issue preventing the app from fully building, I couldn't capture actual screenshots. But here's what changed:
Before - Guest users had to navigate via logout dialog
After - 
if (localApi.userModel.isGuest == true)
     FloatingActionButton(
       onPressed: () => appRouter.pushNamed('/auth'),
       backgroundColor: kYellow,
       child: Icon(Icons.login, color: Colors.white),
     )

Note: Please let me know if screenshots are strictly needed; I can try fixing the build and update later.